### PR TITLE
refactor: clean up WebSocket usage and duplicate endpoints

### DIFF
--- a/src/api/router/health.py
+++ b/src/api/router/health.py
@@ -170,30 +170,6 @@ async def health_check(request: Request):
         "timestamp": datetime.utcnow().isoformat() + "Z"
     }
 
-
-@router.get("/health")
-async def simple_health(request: Request):
-    """
-    Simple health endpoint exactly like Node.js server.
-    Returns basic status with WebSocket and funding info.
-    """
-    # Get WebSocket client count
-    ws_client_count = 0
-    if hasattr(request.app.state, 'ws_manager'):
-        ws_client_count = request.app.state.ws_manager.get_connection_count()
-    
-    # Check if funding is configured  
-    funding_configured = "configured" if settings.FUNDER_PRIVATE_KEY else "not configured"
-    
-    return {
-        "status": "ok",
-        "services": {
-            "websocket": f"{ws_client_count} clients connected",
-            "funding": funding_configured
-        }
-    }
-
-
 @router.get("/metrics", status_code=status.HTTP_200_OK)
 async def get_metrics_endpoint():
     """

--- a/src/core/service/funding/funding_service.py
+++ b/src/core/service/funding/funding_service.py
@@ -172,9 +172,6 @@ class FundingService:
             # Wait for confirmation
             tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
             
-            # Note: WebSocket broadcast removed - funding service should not handle WebSocket directly
-            # If needed, this should be handled at the router level
-            
             return FundingResponse(
                 success=True,
                 funded=True,

--- a/src/core/service/funding/funding_service.py
+++ b/src/core/service/funding/funding_service.py
@@ -1,7 +1,6 @@
 """Funding service for Chain Signatures."""
 
 import os
-import asyncio
 from typing import Dict, Optional
 from decimal import Decimal
 
@@ -173,31 +172,8 @@ class FundingService:
             # Wait for confirmation
             tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
             
-            # Broadcast funding event via WebSocket - exactly like Node.js
-            # broadcast({
-            #   type: 'addressFunded',
-            #   address,
-            #   chainId,
-            #   amount: networkConfig.fundingAmount,
-            #   txHash: tx.hash
-            # })
-            try:
-                from fastapi import FastAPI
-                from starlette.requests import Request
-                
-                # Get app instance to access WebSocket manager
-                # This will be passed from the router
-                if hasattr(request, '_app_state'):
-                    manager = request._app_state.ws_manager
-                    asyncio.create_task(manager.broadcast({
-                        "type": "addressFunded",
-                        "address": checksum_address,
-                        "chainId": request.chain_id,
-                        "amount": network_config['funding_amount'],
-                        "txHash": tx_hash.hex()
-                    }))
-            except Exception as e:
-                logger.warning(f"Failed to broadcast funding event: {e}")
+            # Note: WebSocket broadcast removed - funding service should not handle WebSocket directly
+            # If needed, this should be handled at the router level
             
             return FundingResponse(
                 success=True,


### PR DESCRIPTION
- Remove unnecessary WebSocket broadcast from funding service
- Remove duplicate /health endpoint in health router
- Remove unused asyncio import from funding service
- Improve code organization and separation of concerns

WebSocket functionality should only be handled at router level, not in service layer.